### PR TITLE
Specify expected hash pattern in filename

### DIFF
--- a/Twig/Assets.php
+++ b/Twig/Assets.php
@@ -6,6 +6,8 @@ use Symfony\Component\Finder\Finder;
 
 class Assets extends \Twig_Extension
 {
+  constant HASH_PATTERN = '\.[0-9a-f]{10}';
+
     /**
      * @var string
      */
@@ -43,8 +45,9 @@ class Assets extends \Twig_Extension
      */
     public function gruntAsset($filename)
     {
-        $pattern = vsprintf('%s*.%s', array(
+        $pattern = vsprintf('%s%s\.%s', array(
             pathinfo($filename, PATHINFO_FILENAME),
+            self::HASH_PATTERN,
             pathinfo($filename, PATHINFO_EXTENSION),
         ));
 


### PR DESCRIPTION
We're using a plugin gulp-rev to generate a hash from the file contents
and insert it into the filename.

See: https://github.com/Typeform/gulp-rev

This change is necessary because we use dots to 'namespace' our files.
For example we have:

typeform.admin.js
typeform.admin.account.js

Later we will put a hash on these files so it will look like:

typeform.admin-1234.js
typeform.admin.account-5678.js

In twig, if we want to load typeform.admin.js we would write:

{{ grunt_asset('typeform.admin.js') }}

However this matches both of the aformentioned files. And an exception
is thrown.

Now we tell the twig function to look for:

filname + -hash + .ext
